### PR TITLE
Only add non-empty modules to configuration

### DIFF
--- a/modImportExport.bas
+++ b/modImportExport.bas
@@ -56,7 +56,9 @@ Public Sub MakeConfigFile()
         End Select
 
         If Not strFileExt = vbNullString Then
-            dictModulePaths.Add comModule.Name, comModule.Name & "." & strFileExt
+            If Not ModuleEmpty(comModule) Then
+                dictModulePaths.Add comModule.Name, comModule.Name & "." & strFileExt
+            End If
         End If
 
     Next comModule
@@ -276,6 +278,26 @@ Private Sub ImportModule(ByVal Project As VBProject, ByVal ModuleName As String,
     End If
 
 End Sub
+
+
+Private Function ModuleEmpty(ByVal comModule As VBComponent) As Boolean
+
+    Dim lngNumLines As Long
+    Dim lngCurLine As Long
+    Dim strCurLine As String
+
+    ModuleEmpty = True
+
+    lngNumLines = comModule.CodeModule.CountOfLines
+    For lngCurLine = 1 To lngNumLines
+        strCurLine = comModule.CodeModule.Lines(lngCurLine, 1)
+        If Not (strCurLine = "Option Explicit" Or strCurLine = "") Then
+            ModuleEmpty = False
+            Exit Function
+        End If
+    Next lngCurLine
+
+End Function
 
 
 '// Read an parse the config file for a project


### PR DESCRIPTION
This is a fix for an issue mainly with sheet modules. It is normal
for sheet modules not to have any code. In this case it is
distracting to have empty files in the project directory just for
these. Instead they shouldn't be added to the configuration file.

I hope this won't cause any problems with modules left intentionally
empty.

Implements issue #20 