### PR TITLE
Solve issue29: Create folders on export if nessesary

### DIFF
--- a/modImportExport.bas
+++ b/modImportExport.bas
@@ -404,9 +404,9 @@ Private Function HandleCrash(ByVal ErrNumber As Long, ByVal ErrDesc As String, B
     Dim UserAction As Integer
 
     UserAction = MsgBox( _
-        Prompt = "An unexpected problem occured, would you like to debug?", _
-        Buttons = vbYesNo, _
-        Title = "Unexpected problem")
+        Prompt:="An unexpected problem occured, would you like to debug?", _
+        Buttons:=vbYesNo, _
+        Title:="Unexpected problem")
 
     HandleCrash = UserAction = vbYes
 


### PR DESCRIPTION
See issue #29 for details on the problem.

Makes sure the parent folders of the exported code module files
exist before creating the files. This avoids errors due to the
parent folder not existing.

This branch is based on the syntaxerror branch submitted in PR #33.