### PR TITLE
Set VBAProject name on import

### DIFF
--- a/CodeExport.config.json
+++ b/CodeExport.config.json
@@ -1,4 +1,5 @@
 {
+	"VBAProject Name": "CodeExport",
 	"Module Paths": {
 		"clsVBECmdHandler": "clsVBECmdHandler.cls",
 		"JsonConverter": "JsonConverter.bas",

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The `Module Paths` property specifies a mapping of VBA modules to their location
 
 The `References` property declares the references to libraries that your VBA modules require. These will be imported when the import action is used and will be removed when the export action is used.
 
-The `VBAProject Name` property declares declares the VBAProject name. This will be imported with the import action is used.
+The `VBAProject Name` property declares declares the VBAProject name. This will be imported when the import action is used.
 
 ### Importing
 

--- a/README.md
+++ b/README.md
@@ -27,12 +27,15 @@ The `Module Paths` property specifies a mapping of VBA modules to their location
 
 The `References` property declares the references to libraries that your VBA modules require. These will be imported when the import action is used and will be removed when the export action is used.
 
+The `VBAProject Name` property declares declares the VBAProject name. This will be imported with the import action is used.
+
 ### Importing
 
 The `Import` button in the `Export For VCS` menu will:
 
 * Import all the modules specified in the configuration file from the file system into the Excel file. Existing modules will be overwritten.
 * Add all library references declared in the configuration file. Existing library references will be overwritten.
+* Set the VBAProject name as declared in the configuration file.
 
 
 ### Exporting

--- a/modImportExport.bas
+++ b/modImportExport.bas
@@ -17,6 +17,7 @@ Private Const STR_CONFIGKEY_REFERENCE_GUID          As String = "GUID"
 Private Const STR_CONFIGKEY_REFERENCE_MAJOR         As String = "Major"
 Private Const STR_CONFIGKEY_REFERENCE_MINOR         As String = "Minor"
 Private Const STR_CONFIGKEY_REFERENCE_PATH          As String = "Path"
+Private Const STR_CONFIGKEY_PROJECTNAME             As String = "VBAProject Name"
 
 Private Const ForReading                As Integer = 1
 
@@ -129,20 +130,20 @@ Public Sub Export()
         '// Export each module listed in the module paths to it's designated location
         Set dictModulePaths = dictConfig(STR_CONFIGKEY_MODULEPATHS)
         For Each varModuleName In dictModulePaths.Keys
-    
+
             strModuleName = varModuleName
             strModulePath = dictModulePaths(strModuleName)
             strModulePath = EvaluatePath(prjActProj, strModulePath)
             Set comModule = prjActProj.VBComponents(strModuleName)
-    
+
             comModule.Export strModulePath
-    
+
             If comModule.Type = vbext_ct_Document Then
                 comModule.CodeModule.DeleteLines 1, comModule.CodeModule.CountOfLines
             Else
                 prjActProj.VBComponents.Remove comModule
             End If
-    
+
         Next varModuleName
     End If
 
@@ -150,11 +151,11 @@ Public Sub Export()
         '// For each reference listed in the config file, delete the references in the project
         Set collConfigRefs = dictConfig(STR_CONFIGKEY_REFERENCES)
         For Each dictDeclaredRef In collConfigRefs
-    
+
             If CollectionKeyExists(prjActProj.References, dictDeclaredRef(STR_CONFIGKEY_REFERENCE_NAME)) Then
                 prjActProj.References.Remove prjActProj.References(dictDeclaredRef(STR_CONFIGKEY_REFERENCE_NAME))
             End If
-    
+
         Next dictDeclaredRef
     End If
 
@@ -183,6 +184,7 @@ Public Sub Import()
     Dim varModuleName       As Variant
     Dim strModuleName       As String
     Dim strModulePath       As String
+    Dim strProjName         As String
 
     On Error GoTo catchError
 
@@ -223,6 +225,12 @@ Public Sub Import()
             End If
 
         Next dictDeclaredRef
+    End If
+
+    If dictConfig.Exists(STR_CONFIGKEY_PROJECTNAME) Then
+        '// Set the project name
+        strProjName = dictConfig(STR_CONFIGKEY_PROJECTNAME)
+        prjActProj.Name = strProjName
     End If
 
 exitSub:


### PR DESCRIPTION
Solves issue #31. The VBAProject name is reset if all VBA code
is exported. This is a similar issue to the references issue.
It is solved very simply, by setting the VBAProject.name to the
value given in the configuration file.

This branch is based on the syntaxerror branch submitted in PR #33.