### PR TITLE
Improve crash dialog

### DIFF
--- a/modImportExport.bas
+++ b/modImportExport.bas
@@ -404,9 +404,9 @@ Private Function HandleCrash(ByVal ErrNumber As Long, ByVal ErrDesc As String, B
     Dim UserAction As Integer
 
     UserAction = MsgBox( _
-        Prompt = "An unexpected problem occured, would you like to debug?", _
-        Buttons = vbYesNo, _
-        Title = "Unexpected problem")
+        Prompt:="An unexpected problem occured, would you like to debug?", _
+        Buttons:=vbYesNo, _
+        Title:="Unexpected problem")
 
     HandleCrash = UserAction = vbYes
 

--- a/modImportExport.bas
+++ b/modImportExport.bas
@@ -404,8 +404,14 @@ Private Function HandleCrash(ByVal ErrNumber As Long, ByVal ErrDesc As String, B
     Dim UserAction As Integer
 
     UserAction = MsgBox( _
-        Prompt:="An unexpected problem occured, would you like to debug?", _
-        Buttons:=vbYesNo, _
+        Prompt:= _
+            "An unexpected problem occured. Please report this to " & _
+            "https://github.com/spences10/VBA-IDE-Code-Export/issues" & vbNewLine & vbNewLine & _
+            "Error Number: " & ErrNumber & vbNewLine & _
+            "Error Description: " & ErrDesc & vbNewLine & _
+            "Error Source: " & ErrSource & vbNewLine & vbNewLine & _
+            "Would you like to debug?", _
+        Buttons:=vbYesNo + vbDefaultButton2, _
         Title:="Unexpected problem")
 
     HandleCrash = UserAction = vbYes


### PR DESCRIPTION
Add error information and make sure the user knows that the
problem is not normal and should be reported to the issue tracker.

This branch is based on the syntaxerror branch submitted in PR #33.