### PR TITLE
Add Base Path configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The add-in will create a menu in the VBA IDE (the VBE) called `Export for VCS`. 
 
 A file named `CodeExport.config.json` in the same directory as an Excel file declares what gets imported into that Excel file. The `Make Config File` button in the `Export For VCS` menu will generate a new configuration file for the current active project based upon the contents of that project. Any existing configuration file will be overwritten. The JSON file format is used as the file format for the configuration file.
 
-The `Module Paths` property specifies a mapping of VBA modules to their location in the file system. File paths may be either relative or absolute. Relatives paths are relative to the directory of the configuration file and the Excel file.
+The `Module Paths` property specifies a mapping of VBA modules to their location in the file system. File paths may be either relative or absolute. Relatives paths are relative to the directory of the configuration file and the Excel file. The `Base Path` property can be used to add a common prefix to all the file paths.
 
 The `References` property declares the references to libraries that your VBA modules require. These will be imported when the import action is used and will be removed when the export action is used.
 

--- a/modImportExport.bas
+++ b/modImportExport.bas
@@ -404,9 +404,9 @@ Private Function HandleCrash(ByVal ErrNumber As Long, ByVal ErrDesc As String, B
     Dim UserAction As Integer
 
     UserAction = MsgBox( _
-        Prompt = "An unexpected problem occured, would you like to debug?", _
-        Buttons = vbYesNo, _
-        Title = "Unexpected problem")
+        Prompt:="An unexpected problem occured, would you like to debug?", _
+        Buttons:=vbYesNo, _
+        Title:="Unexpected problem")
 
     HandleCrash = UserAction = vbYes
 


### PR DESCRIPTION
Allow a common prefix to all code module path names.
Solves issue #15.

This branch is based on the syntaxerror branch submitted in PR #33.