### PR TITLE
Blacklist the MSForms reference

### DIFF
--- a/modImportExport.bas
+++ b/modImportExport.bas
@@ -90,7 +90,8 @@ Public Sub MakeConfigFile()
         If Not refReference.BuiltIn Then
             boolForbiddenRef = _
                 refReference.Name = "stdole" Or _
-                refReference.Name = "Office"
+                refReference.Name = "Office" Or _
+                refReference.Name = "MSForms"
             If Not boolForbiddenRef Then
                 Config.ReferencesUpdateFromVBRef refReference
             End If


### PR DESCRIPTION
The MSForms reference seems to be automatically added and raises
an error when it is removed. It is another one of the references
which are 'effectively' built-in but the built-in property is not
set to true.