### PR TITLE
Blacklist MSForms reference

### DIFF
--- a/src/modImportExport.bas
+++ b/src/modImportExport.bas
@@ -90,7 +90,8 @@ Public Sub MakeConfigFile()
         If Not refReference.BuiltIn Then
             boolForbiddenRef = _
                 refReference.Name = "stdole" Or _
-                refReference.Name = "Office"
+                refReference.Name = "Office" Or _
+                refReference.Name = "MSForms"
             If Not boolForbiddenRef Then
                 Config.ReferencesUpdateFromVBRef refReference
             End If


### PR DESCRIPTION
This reference is effectively a built-in reference but the built-in
property doesn't return true.

This is identical to PR #46 but for some reason is not in master any more. Maybe a mistake was made somewhere along the line.